### PR TITLE
Allows workflow pinning to a certain rockcraft revision

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -42,7 +42,7 @@ on:
         default: '{}'
       rockcraft-revision:
         type: string
-        description: >
+        description: |-
           Pin the snap revision to install.
     
           If not provided, it defaults to whatever revision is in latest/stable.

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -40,6 +40,13 @@ on:
           The key should be one of the platforms in rockcraft.yaml (amd64, arm64...)
           the values should be a list of labels to use in the runs-on field of a gh action
         default: '{}'
+      rockcraft-revision:
+        type: string
+        description: >
+          Pin the snap revision to install.
+    
+          If not provided, it defaults to whatever revision is in latest/stable.
+        default: ''
     outputs:
       images:
         description: List of images built
@@ -220,6 +227,7 @@ jobs:
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: ${{ matrix.rock.path }}
+          revision: ${{ inputs.rockcraft-revision }}
       - name: Generate rockcraft container cache
         if: inputs.cache-action == 'save'
         run: |


### PR DESCRIPTION
Allows to use snap revision pinning with the rockcraft-pack action