### PR TITLE
Allow all rock builds to run to completion

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -104,7 +104,7 @@ jobs:
             const defaultArch = 'amd64'
             const platformLabels = JSON.parse(inputs['platform-labels'])
             const rockcraftRevisions = JSON.parse(inputs['rockcraft-revisions'])
-            
+
             core.info(`Multiarch Awareness is ${multiarch ? "on" : "off" }`)
             for (const rockcraftFile of await rockcraftGlobber.glob()) {
               const rockPath = path.relative('.', path.dirname(rockcraftFile)) || "./"
@@ -159,6 +159,7 @@ jobs:
     strategy:
       matrix:
         rock: ${{ fromJSON(needs.get-rocks.outputs.rock-metas) }}
+      fail-fast: false
     runs-on: ${{ matrix.rock.runs-on-labels }}
     permissions:
       contents: read


### PR DESCRIPTION
This simply adds a `fail-fast` to the rock building matrix to allow all Rock builds to finish, which avoids repos with multiple contributors working on rocks in parallel from getting their own rock build cancelled.

Considering that the image publishing step is in a separate workflow file definition, this should NOT negatively affect existing repos using the build workflow. (apart from maybe a some extra time to wait for all the rock builds to finish)

You can check out an [intentionally failing] [workflow run with the new behaviour on my fork here](https://github.com/aznashwan/harbor-rocks/actions/runs/9954725780) FWIW.