### PR TITLE
Assemble multiarch images by name and version key

### DIFF
--- a/.github/files/create-and-push-manifest.js
+++ b/.github/files/create-and-push-manifest.js
@@ -68,7 +68,7 @@ async function main(rockMetas, registry, dryRun) {
         containers[key].images.push(new RockImage(meta.image, meta.arch))
     }
     for (const component of Object.values(containers)) {
-        console.info(`🖥️  Assemble Multiarch Image: ${component.name}`)
+        console.info(`🖥️  Assemble Multiarch Image: ${component.name} version: ${component.version}`)
         await component.craft_manifest(`${registry}/${owner}`)
     }
 }

--- a/.github/files/create-and-push-manifest.js
+++ b/.github/files/create-and-push-manifest.js
@@ -61,10 +61,11 @@ async function main(rockMetas, registry, dryRun) {
     const metas = rockMetas
     const containers = {}
     for (const meta of metas) {
-        if (!containers.hasOwnProperty(meta.name)) {
-            containers[meta.name] = new RockComponent(meta.name, meta.version, dryRun)
+        let key = [meta.name, meta.version]
+        if (!containers.hasOwnProperty(key)) {
+            containers[key] = new RockComponent(meta.name, meta.version, dryRun)
         }
-        containers[meta.name].images.push(new RockImage(meta.image, meta.arch))
+        containers[key].images.push(new RockImage(meta.image, meta.arch))
     }
     for (const component of Object.values(containers)) {
         console.info(`🖥️  Assemble Multiarch Image: ${component.name}`)


### PR DESCRIPTION
### Overview

Allow multiarch rocks to be assembled uniquely by name and version, in the event multiple versions of rocks are being built in the same action workflow

## Details
A multiarch rock should be unique based on its rock name and version name.  The code was ALMOST ready to handle this, except for the last step where the images are assembled into unique manifests.  This change adjusts the final containers to be assembled based on their name and their version.