### PR TITLE
Adds cache-action skip option

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -27,7 +27,7 @@ on:
         default: "./"
       cache-action:
         type: string
-        description: The cache action can either be "save" or "restore".
+        description: The cache action can either be "save", "restore", or "skip".
         default: restore
       multiarch-awareness:
         type: boolean
@@ -81,8 +81,8 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [ "${{ inputs.cache-action }}" != "save" ] && [ "${{ inputs.cache-action }}" != "restore" ]; then
-            echo "Invalid value for cache-action. It must be 'save' or 'restore'"
+          if [ "${{ inputs.cache-action }}" != "save" ] && [ "${{ inputs.cache-action }}" != "restore" ] && [ "${{ inputs.cache-action }}" != "skip" ]; then
+            echo "Invalid value for cache-action. It must be 'save', 'restore', or 'skip'"
             exit 1
           fi
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
In some cases, we are not able to cache the container due to its size, resulting in the entire job failing because it runs out of disk space. We should be able to skip this step in these situations.