### PR TITLE
Fix when image not present in registry during build time

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -146,7 +146,10 @@ jobs:
                             "runs-on-labels": platformLabels[arch] || [inputs["runs-on"]]
                         }
                         rockMetas.push(meta)
-                        if (isPullRequest && changesPaths.includes(`${rockPath}/rockcraft.yaml`)) {
+                        const imageExistCmdOutCode = (
+                            await exec.getExecOutput('docker', ['manifest', 'inspect', image])
+                        ).exitCode
+                        if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
                             changedMetas.push(meta)
                         } else if (!isPullRequest) {
                             changedMetas.push(meta)
@@ -166,7 +169,10 @@ jobs:
                         "runs-on-labels": platformLabels[defaultArch] || [inputs["runs-on"]]
                     };
                     rockMetas.push(meta)
-                    if (isPullRequest && changesPaths.includes(`${rockPath}/rockcraft.yaml`)) {
+                    const imageExistCmdOutCode = (
+                    await exec.getExecOutput('docker', ['manifest', 'inspect', image])
+                    ).exitCode
+                    if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
                         changedMetas.push(meta)
                     } else if (!isPullRequest) {
                         changedMetas.push(meta)

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -136,7 +136,7 @@ jobs:
                         const image = `${{inputs.registry}}/${{inputs.owner}}/${rockName}:${fileHash}-${arch}`
                         core.info(`generate multi-arch image name: ${image}`)
                         images.push(image)
-                        let meta = {
+                        const meta = {
                             name: rockName,
                             version: rockVersion,
                             path: rockPath,
@@ -146,10 +146,8 @@ jobs:
                             "runs-on-labels": platformLabels[arch] || [inputs["runs-on"]]
                         }
                         rockMetas.push(meta)
-                        const imageExistCmdOutCode = (
-                            await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})
-                        ).exitCode
-                        if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
+                        const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true}).exitCode) === 0
+                        if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                             changedMetas.push(meta)
                         } else if (!isPullRequest) {
                             changedMetas.push(meta)
@@ -159,7 +157,7 @@ jobs:
                     const image = `${{inputs.registry}}/${{inputs.owner}}/${rockName}:${fileHash}`
                     core.info(`generate image name: ${image}`)
                     images.push(image)
-                    let meta = {
+                    const meta = {
                         name: rockName,
                         version: rockVersion,
                         path: rockPath,
@@ -169,10 +167,8 @@ jobs:
                         "runs-on-labels": platformLabels[defaultArch] || [inputs["runs-on"]]
                     };
                     rockMetas.push(meta)
-                    const imageExistCmdOutCode = (
-                    await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})
-                    ).exitCode
-                    if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
+                    const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true}).exitCode) === 0
+                    if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                         changedMetas.push(meta)
                     } else if (!isPullRequest) {
                         changedMetas.push(meta)

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -147,7 +147,7 @@ jobs:
                         }
                         rockMetas.push(meta)
                         const imageExistCmdOutCode = (
-                            await exec.getExecOutput('docker', ['manifest', 'inspect', image])
+                            await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})
                         ).exitCode
                         if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
                             changedMetas.push(meta)
@@ -170,7 +170,7 @@ jobs:
                     };
                     rockMetas.push(meta)
                     const imageExistCmdOutCode = (
-                    await exec.getExecOutput('docker', ['manifest', 'inspect', image])
+                    await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})
                     ).exitCode
                     if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || (imageExistCmdOutCode !== 0))) {
                         changedMetas.push(meta)


### PR DESCRIPTION
In some cases, mechanics for skipping not changed Rockcraft files cause build errors, for example when pr was merged even when failing. This PR fixes that issue.

KU-1195