### PR TITLE
fix for unnesesary triggered rock build

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -146,7 +146,7 @@ jobs:
                             "runs-on-labels": platformLabels[arch] || [inputs["runs-on"]]
                         }
                         rockMetas.push(meta)
-                        const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true}).exitCode) === 0
+                        const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})).exitCode === 0
                         if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                             changedMetas.push(meta)
                         } else if (!isPullRequest) {
@@ -167,7 +167,7 @@ jobs:
                         "runs-on-labels": platformLabels[defaultArch] || [inputs["runs-on"]]
                     };
                     rockMetas.push(meta)
-                    const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true}).exitCode) === 0
+                    const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})).exitCode === 0
                     if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                         changedMetas.push(meta)
                     } else if (!isPullRequest) {


### PR DESCRIPTION
builds were not skipped when rockfile was not changed. This pr fixes it, exit code from checking if the image exists was improperly called.