### PR TITLE
Sending trivy CVEs to Jira

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -95,4 +95,4 @@ jobs:
         git pull -q origin patch-1
         cd -       
         # send scans from supplied directory
-        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} 
+        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} --add-github-meta --verbose 

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -82,8 +82,8 @@ jobs:
       env:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
-
     - name: Send vulnerability records to jira
+      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         CI_REPO="https://github.com/canonical/kubeflow-ci.git"
@@ -93,9 +93,6 @@ jobs:
         git remote add -f origin "$CI_REPO" &> /dev/null
         git sparse-checkout set scripts/cve-reports/send-scan.py
         git pull -q origin main
-        cd -
-        ls
-        cat trivy-results.sarif
-        
+        cd -       
         # send scans from supplied directory
         ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }}

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -83,7 +83,7 @@ jobs:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
     - name: Send vulnerability records to jira
-      if: ${{ inputs.upload-result }}
+#      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         #CI_REPO="https://github.com/canonical/kubeflow-ci.git"

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -83,7 +83,7 @@ jobs:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
     - name: Send vulnerability records to jira
-#      if: ${{ inputs.upload-result }}
+      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         CI_REPO="https://github.com/canonical/kubeflow-ci.git"
@@ -95,4 +95,4 @@ jobs:
         git pull -q origin main
         cd -       
         # send scans from supplied directory
-        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} --add-github-meta --verbose 
+        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} --add-github-meta 

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -83,16 +83,16 @@ jobs:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
     - name: Send vulnerability records to jira
+      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         #CI_REPO="https://github.com/canonical/kubeflow-ci.git"
-        CI_REPO="https://github.com/maci3jka/kubeflow-ci.git"
         mkdir -p kubeflow-ci
         cd kubeflow-ci
         git init -q
         git remote add -f origin "$CI_REPO" &> /dev/null
         git sparse-checkout set scripts/cve-reports/send-scan.py
-        git pull -q origin patch-1
+        git pull -q origin main
         cd -       
         tail ./kubeflow-ci/scripts/cve-reports/send-scan.py
         # send scans from supplied directory

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -90,9 +90,9 @@ jobs:
         mkdir -p kubeflow-ci
         cd kubeflow-ci
         git init -q
-        git remote add -f origin -b patch-1 "$CI_REPO" &> /dev/null
+        git remote add -f origin "$CI_REPO" &> /dev/null
         git sparse-checkout set scripts/cve-reports/send-scan.py
-        git pull -q origin main
+        git pull -q origin patch-1
         cd -       
         # send scans from supplied directory
         ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} 

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -86,7 +86,7 @@ jobs:
 #      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
-        #CI_REPO="https://github.com/canonical/kubeflow-ci.git"
+        CI_REPO="https://github.com/canonical/kubeflow-ci.git"
         mkdir -p kubeflow-ci
         cd kubeflow-ci
         git init -q
@@ -94,6 +94,5 @@ jobs:
         git sparse-checkout set scripts/cve-reports/send-scan.py
         git pull -q origin main
         cd -       
-        tail ./kubeflow-ci/scripts/cve-reports/send-scan.py
         # send scans from supplied directory
         ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} --add-github-meta --verbose 

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -98,5 +98,4 @@ jobs:
         cat trivy-results.sarif
         
         # send scans from supplied directory
-        # todo uncoment when
-        #./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }}
+        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }}

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -82,3 +82,21 @@ jobs:
       env:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
+
+    - name: Send vulnerability records to jira
+      run: |
+        # get script that sends scan results from Kubeflow CI repo
+        CI_REPO="https://github.com/canonical/kubeflow-ci.git"
+        mkdir -p kubeflow-ci
+        cd kubeflow-ci
+        git init -q
+        git remote add -f origin "$CI_REPO" &> /dev/null
+        git sparse-checkout set scripts/cve-reports/send-scan.py
+        git pull -q origin main
+        cd -
+        ls
+        cat trivy-results.sarif
+        
+        # send scans from supplied directory
+        # todo uncoment when
+        #./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }}

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -86,11 +86,12 @@ jobs:
       if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
-        CI_REPO="https://github.com/canonical/kubeflow-ci.git"
+        #CI_REPO="https://github.com/canonical/kubeflow-ci.git"
+        CI_REPO="https://github.com/maci3jka/kubeflow-ci.git"
         mkdir -p kubeflow-ci
         cd kubeflow-ci
         git init -q
-        git remote add -f origin "$CI_REPO" &> /dev/null
+        git remote add -f origin -b patch-1 "$CI_REPO" &> /dev/null
         git sparse-checkout set scripts/cve-reports/send-scan.py
         git pull -q origin main
         cd -       

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -94,5 +94,6 @@ jobs:
         git sparse-checkout set scripts/cve-reports/send-scan.py
         git pull -q origin patch-1
         cd -       
+        tail ./kubeflow-ci/scripts/cve-reports/send-scan.py
         # send scans from supplied directory
         ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} --add-github-meta --verbose 

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -83,7 +83,6 @@ jobs:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
     - name: Send vulnerability records to jira
-#      if: ${{ inputs.upload-result }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         #CI_REPO="https://github.com/canonical/kubeflow-ci.git"
@@ -96,4 +95,4 @@ jobs:
         git pull -q origin main
         cd -       
         # send scans from supplied directory
-        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }}
+        ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=trivy-results.sarif --jira-url=${{ secrets.JIRA_URL }} 


### PR DESCRIPTION
This PR adds to the image scan step that pushes CVEs found by trivy to the Jira webhook, on Jira side received data gets created into issues.

KU-1194