### PR TITLE
Adds running lint step to run_tests.yaml

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -45,6 +45,9 @@ jobs:
             image=$(echo "$i" | jq -r '.image')
             echo "ROCK_$name=$image" >> $GITHUB_ENV
           done
+      - name: Run lint
+        run: |
+          tox --conf tests/tox.ini -e lint
       - name: Run sanity tests
         env:
           BUILT_ROCKS_METADATA: ${{ inputs.rock-metas }}


### PR DESCRIPTION
Some rock repositories have linting issues because this action did not specifically test for them.