### PR TITLE
Conditionally send updates to Jira

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -83,7 +83,9 @@ jobs:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
     - name: Send vulnerability records to jira
-      if: ${{ inputs.upload-result }}
+      env:
+        JIRA_URL: ${{ secrets.JIRA_URL }}
+      if: ${{ inputs.upload-result && env.JIRA_URL != '' }}
       run: |
         # get script that sends scan results from Kubeflow CI repo
         CI_REPO="https://github.com/canonical/kubeflow-ci.git"


### PR DESCRIPTION
We shouldn't send updates to Jira if we don't have the URL configured. This will prevent the ``scan_images`` to fail if the secret is not set (typical for forks).