### PR TITLE
Adds additional tag without -ckN suffix

### DIFF
--- a/.github/workflows/assemble_multiarch_image.yaml
+++ b/.github/workflows/assemble_multiarch_image.yaml
@@ -84,3 +84,7 @@ jobs:
           const rockMetas = JSON.parse(`${{ steps.assemble-image-tags.outputs.rock-metas }}`)
           ${{ steps.create-and-push-manifest-js.outputs.content }}
           await main(rockMetas, registry, dryRun)
+
+          // Create and push manifests for versions without the -ckN suffix.
+          const metas = JSON.parse(`${{ inputs.rock-metas }}`)
+          await main(metas, registry, dryRun)


### PR DESCRIPTION
Currently, we publish manifest lists for each image and version with the ``-ckN`` suffix, where N is the number of versions we have published for that rock.

This commit also publishes the same manifest lists without the ``-ckN`` suffix. This will help in 2 regards:

- We typically want to deploy the latest version of a published rock. When it comes to user experience, it's a lot easier to just use the ``ghcr.io/canonical/foo:1.0.0`` rock, rather than ``ghcr.io/canonical/foo:1.0.0-ckN``, where a user would have too manually check what is the latest N revision of that rock. This issue is even more egregious in cases in which we'd need multiple rocks for the same application deployment (e.g.: Longhorn).
- The documentation where these rocks are referenced with the -ckN suffix will get outdated over time, referencing an out-of-date revision. Instead, the manifest list without the ``-ckN`` suffix will always point towards the latest revision.

The ``-ckN`` manifest lists are still published, so a user may still be able to pick a previous revision if needed.