### PR TITLE
Use alternate Trivy registry

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -68,7 +68,7 @@ jobs:
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0
         if [ -f ".trivyignore" ]
         then
-          output=$(trivy image $IMAGE_REF --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
+          output=$(trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 $IMAGE_REF --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
           line=0
           while read CVE;
           do


### PR DESCRIPTION
The Trivy job fails most of the time, being unable to fetch the Trivy image due to rate limiting.

https://github.com/aquasecurity/trivy/discussions/7538

To solve this, we'll use an alternate Trivy registry.