### PR TITLE
Update trivy job, using alternate registry

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -58,6 +58,7 @@ jobs:
       env:
         TRIVY_USERNAME: ${{ github.actor }}
         TRIVY_PASSWORD: ${{ github.token }}
+        TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db"
     - name: Upload Trivy scan results to GitHub Security tab
       if: ${{ inputs.upload-result }}
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
We've just updated the Trivy job to use an alternate image registry. However, it looks like there's one other step that needs to be updated.