### PR TITLE
CVE reports: Adds ability to always send CISA CVEs to Jira

### DIFF
--- a/scripts/cve-reports/send-scan.py
+++ b/scripts/cve-reports/send-scan.py
@@ -47,6 +47,7 @@ priority_to_level_map = {
     PRIORITY_LOW: LEVEL_LOW,
     PRIORITY_LOWEST: LEVEL_LOWEST,
 }
+level_to_priority_map = {v: k for k, v in priority_to_level_map.items()}
 
 
 def get_github_meta() -> Dict[str, str]:
@@ -155,26 +156,51 @@ def parse_sarif(filename: Path) -> List[Dict[str, str]]:
     return record_list
 
 
-def filter_records(records: List[Dict[str, str]], min_level: int) -> List[Dict[str, str]]:
-    """Filters the records based on the given minimum level.
+def filter_records(
+    records: List[Dict[str, str]], min_level: int, cisa_cve_ids: List[str]
+) -> List[Dict[str, str]]:
+    """Filters the records based on the given minimum level and if it's a CISA CVE.
 
     Args:
       records(List[Dict[str, str]]): List of CVE dictionaries.
       min_level(int): Minimum CVE level used for filtering the CVEs.
+      cisa_cve_ids(List[str]): The CISA CVE catalog list. If a report contains a CVE listed
+        in the catalog, it will be sent to Jira, regardless of the severity level.
     Returns:
-      List[Dict[str, str]]: List of CVE dictionaries which satisfy the criteria.
+      List[Dict[str, str]]: List of CISA CVEs dictionaries.
+      List[Dict[str, str]]: List of CVE dictionaries which satisfy the minimum level criteria.
+        Does not include the CISA CVEs.
       List[Dict[str, str]]: List of CVE dictionaries which do not satisfy the criteria.
     """
-    result = []
+    cisa_records = []
+    other_records = []
     excluded = []
     for record in records:
         level = priority_to_level_map[record["priority"]]
-        if level >= min_level:
-            result.append(record)
+        if record["cve_id"] in cisa_cve_ids:
+            cisa_records.append(record)
+        elif level >= min_level:
+            other_records.append(record)
         else:
             excluded.append(record)
 
-    return result, excluded
+    return cisa_records, other_records, excluded
+
+
+def update_cisa_records(records: List[Dict[str, str]]) -> None:
+    """Update the CISA CVE records.
+
+    Each record will be updated to have at least the 'High' priority, and their name will
+    be updated to include '[CISA] '.
+
+    Args:
+      records(List[Dict[str, str]]): List of CISA CVE dictionaries.
+    """
+    for record in records:
+        level = priority_to_level_map[record["priority"]]
+        level = max(level, LEVEL_HIGH)
+        record["priority"] = level_to_priority_map[level]
+        record["name"] = f"[CISA] {record['name']}"
 
 
 def send_request_with_records(
@@ -214,6 +240,7 @@ def main(
     jira_auth_token: str,
     gh_meta: bool,
     min_level: int,
+    cisa_catalog_path: str,
     verbose: bool,
 ) -> None:
     """Main function for processing CVE's files.
@@ -225,6 +252,8 @@ def main(
         https://support.atlassian.com/cloud-automation/docs/configure-the-incoming-webhook-trigger-in-atlassian-automation/
       gh_meta(bool): if True GitHub metadata will be attached to the request.
       min_level(int): Minimum CVE level used for filtering the CVEs.
+      cisa_catalog_path(str): The path to the CISA CVE catalog JSON file. If a report contains
+        a CVE listed in the catalog, it will be sent to Jira, regardless of the severity level.
       verbose(bool): if True GitHub metadata will be attached to the request.
     """
 
@@ -244,6 +273,17 @@ def main(
         logger.error(f"Failed to retrieve list of files from {report_path}")
         return
 
+    cisa_cve_ids = []
+    if cisa_catalog_path:
+        catalog_path = Path(cisa_catalog_path)
+        if not catalog_path.is_file():
+            logger.error(f"Invalid CISA catalog path '{cisa_catalog_path} supplied")
+            return
+
+        with open(catalog_path, "r") as json_file:
+            cisa_json = json.load(json_file)
+            cisa_cve_ids = [vuln["cveID"] for vuln in cisa_json["vulnerabilities"]]
+
     for file in file_list:
         logger.info(f"Processing report in: {file}")
         if file.suffix == ".json":
@@ -255,11 +295,13 @@ def main(
             continue
 
         # Filter the records we send to Jira.
-        records, excluded = filter_records(records, min_level)
+        cisa_records, other_records, excluded = filter_records(records, min_level, cisa_cve_ids)
         for record in excluded:
             logger.info(f"Skipping {record['name']} with priority {record['priority']}")
 
-        send_request_with_records(records, jira_url, jira_auth_token, gh_metadata, verbose)
+        update_cisa_records(cisa_records)
+        send_request_with_records(cisa_records, jira_url, jira_auth_token, gh_metadata, verbose)
+        send_request_with_records(other_records, jira_url, jira_auth_token, gh_metadata, verbose)
 
 
 if __name__ == "__main__":
@@ -269,6 +311,7 @@ if __name__ == "__main__":
     parser.add_argument("--jira-auth-token", default="")
     parser.add_argument("--add-github-meta", action="store_true")
     parser.add_argument("--minimum-level", default=PRIORITY_LOWEST)
+    parser.add_argument("--cisa-catalog", default="")
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
@@ -286,5 +329,6 @@ if __name__ == "__main__":
         args.jira_auth_token,
         args.add_github_meta,
         min_level,
+        args.cisa_catalog,
         args.verbose,
     )

--- a/scripts/cve-reports/tests/test_cve_reports.py
+++ b/scripts/cve-reports/tests/test_cve_reports.py
@@ -44,7 +44,7 @@ def test_filter_records():
     priority = send_scan.PRIORITY_HIGH
     level = send_scan.priority_to_level_map[priority]
 
-    result, excluded = send_scan.filter_records(records, level)
+    _, result, excluded = send_scan.filter_records(records, level, [])
 
     assert len(result) == 20, f"Expected to get 20 {priority} records."
     assert len(excluded) == 12, f"Expected to exclude 12 lower than {priority} records."
@@ -60,3 +60,53 @@ def test_filter_records():
         assert (
             record_level < level
         ), f"Expected excluded records to have priority level less than {level}. {record['name']} has {record_level}."
+
+
+def test_filter_cisa_records():
+    sarif_path = TESTS_FOLDER.joinpath("test-report.sarif")
+    records = send_scan.parse_sarif(sarif_path)
+    priority = send_scan.PRIORITY_HIGHEST
+    level = send_scan.priority_to_level_map[priority]
+    cisa_cve_id = "CVE-2022-2873"
+
+    cisa_cves, other_cves, excluded = send_scan.filter_records(records, level, [cisa_cve_id])
+
+    assert len(cisa_cves) == 1, f"Expected to get 1 CISA CVE record."
+    assert len(other_cves) == 7, f"Expected to get 20 {priority} records."
+    assert len(excluded) == 24, f"Expected to exclude 12 lower than {priority} records."
+
+    for record in cisa_cves:
+        assert (
+            cisa_cve_id == record["cve_id"]
+        ), "Expected returned CISA CVEs to only contain given IDs."
+
+    for record in other_cves:
+        assert (
+            cisa_cve_id != record["cve_id"]
+        ), "Expected returned other CVEs to not contain CISA CVE IDs."
+
+    for record in excluded:
+        assert (
+            cisa_cve_id != record["cve_id"]
+        ), "Expected excluded CVEs to not contain CISA CVE IDs."
+
+
+def test_update_cisa_records():
+    records = [
+        {
+            "name": "foo",
+            "priority": send_scan.PRIORITY_LOWEST,
+        },
+        {
+            "name": "foo",
+            "priority": send_scan.PRIORITY_HIGHEST,
+        },
+    ]
+
+    send_scan.update_cisa_records(records)
+
+    assert send_scan.PRIORITY_HIGH == records[0]["priority"]
+    assert send_scan.PRIORITY_HIGHEST == records[1]["priority"]
+
+    for record in records:
+        assert record["name"].startswith("[CISA] ")


### PR DESCRIPTION
``send-scan.py`` can now receive a ``--cisa-catalog`` argument for a JSON file. The CVEs in the reports that are present in the CISA catalog will always be sent to Jira, regardless of their severity. The CISA CVEs will have their Jira card set to at least "High" priority, and will include "[CISA] " in the name.