### PR TITLE
actions: Adds bump-cisa-cves input to send-cve-reports action

### DIFF
--- a/.github/actions/send-cve-reports/action.yaml
+++ b/.github/actions/send-cve-reports/action.yaml
@@ -16,6 +16,13 @@ inputs:
     description: "Minimum severity level to report"
     required: false
     default: "MEDIUM"
+  bump-cisa-cves:
+    description: |
+      Bump the CVE records found from the CISA KEV catalog to at least HIGH priority.
+      These CVEs will have their record names prefixed with "[CISA] ", and will not
+      be affected by the minimum-level argument.
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -29,10 +36,19 @@ runs:
     - name: Send vulnerability records
       shell: bash
       run: |
+        cisa_catalog=""
+        if [[ "${{ inputs.bump-cisa-cves }}" == "true" ]]; then
+          # Obtain CISA Known Exploited Vulnerabilities list.
+          curl -sSL -o ./cisa_kev_catalog.json \
+            https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+          cisa_catalog="./cisa_kev_catalog.json"
+        fi
+
         IFS=',' read -ra REPORTS <<< "${{ inputs.reports }}"
         for report in "${REPORTS[@]}"; do
           ./k8s-workflows/scripts/cve-reports/send-scan.py --report-path="$report" \
             --jira-url="${{ inputs.jira-url }}" \
             --jira-auth-token="${{ inputs.jira-auth-token }}" \
+            --cisa-catalog=$cisa_catalog \
             --add-github-meta --minimum-level="${{ inputs.minimum-level }}" --verbose
         done


### PR DESCRIPTION
If true, we'll bump the priority of the CVEs from the CISA KEV catalog present in the given reports to at least a HIGH priority and prefixing with `"[CISA] "` before sending them to Jira.

Note that these CVEs will not be affected by the `minimum-level` argument.