### PR TITLE
feat: Add support for Ubuntu Pro-based ROCK builds

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -353,7 +353,7 @@ jobs:
           runcmd:
             - |
               # We use a staging token here to avoid load on the production contracts service.
-              # echo \"contract_url: https://contracts.staging.canonical.com\" > /etc/ubuntu-advantage/uaclient.conf
+              echo \"contract_url: https://contracts.staging.canonical.com\" > /etc/ubuntu-advantage/uaclient.conf
             - pro attach ${{ secrets.UBUNTU_PRO_TOKEN }} --no-auto-enable
             - reboot" | multipass launch --name rock-builder --cloud-init - --cpus 4 --disk 20GB --memory 8GB ${{ inputs.multipass-image }} || true
           multipass exec rock-builder -- sudo snap install rockcraft --channel=edge/pro-sources --classic


### PR DESCRIPTION
This pull request enhances the `build_rocks.yaml` workflow to support building rocks with Ubuntu Pro features using Multipass. See [this tutorial](https://github.com/canonical/metallb-rocks/actions/runs/15997381540/job/45123827969?pr=12) for more context.

### Additions for Ubuntu Pro features:

* Added new inputs `multipass-image` and `enabled-ubuntu-pro-features` to specify the Multipass image and enable Ubuntu Pro features, respectively.
* Introduced a new secret, `UBUNTU_PRO_TOKEN`, required for building rocks with Ubuntu Pro features.

### Workflow logic updates:

* Updated conditional logic in existing steps to ensure they only run when `enabled-ubuntu-pro-features` is not set. [[1]](diffhunk://#diff-82226ef4492304cb1468fed8dc92039c452bcfe6bd34974fefc9ac40377c01d9L274-R291) [[2]](diffhunk://#diff-82226ef4492304cb1468fed8dc92039c452bcfe6bd34974fefc9ac40377c01d9L289-R346)

### New steps for Multipass and Ubuntu Pro:

* Added a step to set up Multipass when `enabled-ubuntu-pro-features` is specified, including authentication and configuration.
* Added a step to build ROCKs on an Ubuntu Pro-enabled Multipass instance, including attaching the Ubuntu Pro token and mounting the workspace.