### PR TITLE
Revert "Adds additional tag without -ckN suffix"

### DIFF
--- a/.github/workflows/assemble_multiarch_image.yaml
+++ b/.github/workflows/assemble_multiarch_image.yaml
@@ -84,7 +84,3 @@ jobs:
           const rockMetas = JSON.parse(`${{ steps.assemble-image-tags.outputs.rock-metas }}`)
           ${{ steps.create-and-push-manifest-js.outputs.content }}
           await main(rockMetas, registry, dryRun)
-
-          // Create and push manifests for versions without the -ckN suffix.
-          const metas = JSON.parse(`${{ inputs.rock-metas }}`)
-          await main(metas, registry, dryRun)


### PR DESCRIPTION
Reverts canonical/k8s-workflows#23

This is reverted to prevent overwriting existing image tags (without -ckN suffix).