### PR TITLE
ci: enable LXD guest Pro attachment in build_rocks

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -504,15 +504,12 @@ jobs:
           sudo lxc --project rockcraft import ~/.rockcraft-cache/${{ env.IMAGE_NAME }}.tar ${{ env.ROCKCRAFT_CONTAINER_NAME }}
           find . -exec touch '{}' ';'
       - name: Setup rockcraft
-        env:
-          REVISION: ${{ matrix.rock.rockcraft-revision }}
-          CHANNEL: ${{ matrix.rock.rockcraft-channel || 'latest/stable' }}
+        # TEMPORARY (verification only): force the rockcraft snap from the
+        # latest/edge/checkdowngrade branch to validate the FIPS libgcrypt20
+        # downgrade fix. This overrides the per-rock revision/channel and MUST
+        # be reverted before merging.
         run: |
-          if [[ -n "$REVISION" ]]; then
-            sudo snap install rockcraft --classic --revision "$REVISION"
-          else
-            sudo snap install rockcraft --classic --channel "$CHANNEL"
-          fi
+          sudo snap install rockcraft --classic --channel latest/edge/checkdowngrade
       - name: Create Go cache directories
         if: inputs.enable-go-caching == true && env.GO_DETECTED == 'true'
         run: |

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -488,6 +488,14 @@ jobs:
           fi
       - name: Setup LXD
         uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd # v0.1.3
+      - name: Enable LXD guest Pro attachment
+        # Allow rockcraft build containers (LXD guests) to auto-attach to the
+        # host's Ubuntu Pro subscription. Required since craft-providers
+        # switched to `pro auto-attach` guest attachment. Must run after the
+        # host is Pro-attached and LXD is initialized.
+        if: inputs.enabled-ubuntu-pro-features != ''
+        run: |
+          sudo pro config set lxd_guest_attach=on
       - name: Import rockcraft container cache
         if: steps.rockcraft-cache.outputs.cache-hit == 'true'
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -92,6 +92,13 @@ on:
           When enabled, Go dependencies and build artifacts are cached between workflow runs
           to reduce network requests and improve build reliability on self-hosted runners.
         default: true
+      force-build:
+        type: boolean
+        description: |-
+          Force building every discovered rock, even if an image with the same
+          content hash already exists in the registry. Useful for verification
+          runs where you want to rebuild all rocks regardless of cache.
+        default: false
     secrets:
       UBUNTU_PRO_TOKEN:
         required: false
@@ -160,6 +167,7 @@ jobs:
             const changesPaths = JSON.parse(changes['outputs']['rocks_files'])
             const platformLabels = JSON.parse(inputs['platform-labels'])
             const rockcraftRevisions = JSON.parse(inputs['rockcraft-revisions'])
+            const forceBuild = inputs['force-build']
             const isPullRequest = ${{ github.event_name == 'pull_request' }}
             core.info(`Multiarch Awareness is ${multiarch ? "on" : "off"}`)
 
@@ -258,7 +266,9 @@ jobs:
                         }
                         rockMetas.push(meta)
                         const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})).exitCode === 0
-                        if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
+                        if (forceBuild) {
+                            changedMetas.push(meta)
+                        } else if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                             changedMetas.push(meta)
                         } else if (!isPullRequest) {
                             changedMetas.push(meta)
@@ -292,7 +302,9 @@ jobs:
                     };
                     rockMetas.push(meta)
                     const imageExists = (await exec.getExecOutput('docker', ['manifest', 'inspect', image], {ignoreReturnCode: true})).exitCode === 0
-                    if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
+                    if (forceBuild) {
+                        changedMetas.push(meta)
+                    } else if (isPullRequest && (changesPaths.includes(`${rockPath}/rockcraft.yaml`) || !imageExists)) {
                         changedMetas.push(meta)
                     } else if (!isPullRequest) {
                         changedMetas.push(meta)

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -504,12 +504,15 @@ jobs:
           sudo lxc --project rockcraft import ~/.rockcraft-cache/${{ env.IMAGE_NAME }}.tar ${{ env.ROCKCRAFT_CONTAINER_NAME }}
           find . -exec touch '{}' ';'
       - name: Setup rockcraft
-        # TEMPORARY (verification only): force the rockcraft snap from the
-        # latest/edge/checkdowngrade branch to validate the FIPS libgcrypt20
-        # downgrade fix. This overrides the per-rock revision/channel and MUST
-        # be reverted before merging.
+        env:
+          REVISION: ${{ matrix.rock.rockcraft-revision }}
+          CHANNEL: ${{ matrix.rock.rockcraft-channel || 'latest/stable' }}
         run: |
-          sudo snap install rockcraft --classic --channel latest/edge/checkdowngrade
+          if [[ -n "$REVISION" ]]; then
+            sudo snap install rockcraft --classic --revision "$REVISION"
+          else
+            sudo snap install rockcraft --classic --channel "$CHANNEL"
+          fi
       - name: Create Go cache directories
         if: inputs.enable-go-caching == true && env.GO_DETECTED == 'true'
         run: |


### PR DESCRIPTION
## Summary
Rockcraft builds that use Ubuntu Pro features (e.g. FIPS) currently fail on recent `rockcraft`/`craft-providers` with:

```
Failed to attach '<container>' to a Pro subscription.
```

This is because `craft-providers` ([PR #890](https://github.com/canonical/craft-providers/pull/890)) replaced the old token-based Pro attachment (`attach_pro_subscription(pro_token, contract_url)`) with **LXD guest auto-attachment** — the build container now runs `pro auto-attach` and relies on the host having enabled LXD guest attachment. The `build_rocks` workflow only ran `sudo pro attach $TOKEN` on the host and never enabled guest attachment, so every Pro build container failed to attach.

## Change
Add a dedicated step right after `Setup LXD` that runs:

```sh
sudo pro config set lxd_guest_attach=on
```

It is gated on `inputs.enabled-ubuntu-pro-features != ''` and is placed after both the host Pro-attach and LXD initialization (the `pro config set` call talks to the LXD daemon, so LXD must already be up).

## Testing
Verified from a `cilium-rocks` branch that points its `build_rocks.yaml` reference at this branch (FIPS Pro builds on `latest/edge` rockcraft). Link to follow.

## Refs
- craft-providers guest attachment: https://github.com/canonical/craft-providers/pull/890
- LXD Ubuntu Pro guest attach howto: https://documentation.ubuntu.com/lxd/latest/howto/instances_ubuntu_pro_attach/

## Force built flag
In addition this PR adds a force build flag that is used to for building every discovered rock, even if an image with the same content hash already exists in the registry. This is very useful for verification runs where you want to rebuild all rocks regardless of cache.